### PR TITLE
panic: assignment to entry in nil map

### DIFF
--- a/cloud/cmds/use_cluster.go
+++ b/cloud/cmds/use_cluster.go
@@ -75,6 +75,9 @@ func UseCluster(ctx context.Context, opts *options.ClusterUseConfig, konf *api.K
 			Preferences: clientcmdapi.Preferences{
 				Colors: true,
 			},
+			Clusters:  make(map[string]*clientcmdapi.Cluster),
+			AuthInfos: make(map[string]*clientcmdapi.AuthInfo),
+			Contexts:  make(map[string]*clientcmdapi.Context),
 		}
 	}
 


### PR DESCRIPTION
goroutine 1 [running]:
github.com/pharmer/pharmer/cloud/cmds.UseCluster(0x28b7760, 0xc420b27ef0, 0xc4201d2d40, 0xc4206cc0e0)
	/home/sanjid/go/src/github.com/pharmer/pharmer/cloud/cmds/use_cluster.go:93 +0x30a
github.com/pharmer/pharmer/cloud/cmds.NewCmdUse.func1(0xc4205d0f00, 0xc420910d30, 0x1, 0x1)
	/home/sanjid/go/src/github.com/pharmer/pharmer/cloud/cmds/use_cluster.go:49 +0x361
